### PR TITLE
Fix language update logic in seeder

### DIFF
--- a/backend/video_redirector/mirrors/seed_mirrors_from_json.py
+++ b/backend/video_redirector/mirrors/seed_mirrors_from_json.py
@@ -42,7 +42,10 @@ for entry in mirror_data:
             # Update the fields
             existing.name = name.lower()
             existing.geo = geo
-            existing.lang = [s.strip() for s in lang.split(",")]
+            if isinstance(lang, str):
+                existing.lang = [s.strip() for s in lang.split(",")]
+            else:
+                existing.lang = lang
             existing.mirror_type = mirror_type
             updated += 1
         else:


### PR DESCRIPTION
## Summary
- ensure `existing.lang` handles list input correctly in seeding script

## Testing
- `pytest -q` *(fails: ProxyError)*
- `PYTHONPATH=.. python video_redirector/mirrors/seed_mirrors_from_json.py` *(fails: no such table: mirrors)*

------
https://chatgpt.com/codex/tasks/task_e_683fe895fd48832fb6a07a9babe1b15e