### PR TITLE
Fix static and template path configuration

### DIFF
--- a/backend/video_redirector/main.py
+++ b/backend/video_redirector/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 
 from backend.video_redirector.hdrezka import router as hdrezka_router
 from backend.video_redirector.utils.redis_client import RedisClient
@@ -7,7 +8,10 @@ from backend.video_redirector.routes.mirror_search_route import  router as mirro
 
 app = FastAPI()
 
-app.mount("/static", StaticFiles(directory="video_redirector/static"), name="static")
+BASE_DIR = Path(__file__).resolve().parent
+STATIC_DIR = BASE_DIR / "static"
+
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 #TODO: CHANGE DEPRECATED METHODS
 @app.on_event("startup")

--- a/backend/video_redirector/utils/templates.py
+++ b/backend/video_redirector/utils/templates.py
@@ -1,3 +1,7 @@
 from fastapi.templating import Jinja2Templates
+from pathlib import Path
 
-templates = Jinja2Templates(directory="video_redirector/templates")
+BASE_DIR = Path(__file__).resolve().parent.parent
+TEMPLATES_DIR = BASE_DIR / "templates"
+
+templates = Jinja2Templates(directory=TEMPLATES_DIR)


### PR DESCRIPTION
## Summary
- fix mount path for static files
- fix template path resolution

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683fe66c3160832fb142776629f6ff92